### PR TITLE
Update Makefile to enforce C++17 build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@
 RACK_DIR ?= ../..
 
 # FLAGS will be passed to both the C and C++ compiler
-FLAGS += -std=c++17 -I ./src/gmtl
+FLAGS += -I ./src/gmtl
 CFLAGS +=
-CXXFLAGS +=
+CXXFLAGS += -std=c++17
 
 # Careful about linking to shared libraries, since you can't assume much about the user's environment and library search path.
 # Static libraries are fine, but they should be added to this plugin's build system.
@@ -21,3 +21,5 @@ DISTRIBUTABLES += $(wildcard presets)
 
 # Include the Rack plugin Makefile framework
 include $(RACK_DIR)/plugin.mk
+
+CXXFLAGS := $(filter-out -std=c++11,$(CXXFLAGS))


### PR DESCRIPTION
Previously:
```
g++ -std=c++11 -Wsuggest-override  -std=c++17 -I ./src/gmtl 
[snipped]
```
Now:
```
g++ -std=c++17 -Wsuggest-override -I ./src/gmtl
[snipped]
```
